### PR TITLE
check string is null

### DIFF
--- a/src/number-format.js
+++ b/src/number-format.js
@@ -44,7 +44,7 @@ export default function NumberFormat(config = options) {
 
   this.toNumber = (string) => Number(string)
 
-  this.numberOnly = (string, regExp) => string.toString().replace(regExp, '')
+  this.numberOnly = (string, regExp) => string?.toString().replace(regExp, '')
 
   this.isNegative = this.sign() === '-'
 


### PR DESCRIPTION
This removes the error when the value is null. 
Works well with nullValue: null and C# nullable decimal (Decimal?)