### PR TITLE
fix: #54 When the value is cleared externally, maskedValue is not cleared

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -78,7 +78,7 @@ export default Vue.extend({
   data() {
     return {
       maskedValue: this.value,
-      unmaskedValue: '' as Input | undefined
+      unmaskedValue: this.value as Input | undefined
     }
   },
   computed: {

--- a/tests/component/component.spec.ts
+++ b/tests/component/component.spec.ts
@@ -11,6 +11,18 @@ describe('VueNumber', () => {
     expect(wrapper.contains('input')).toBe(true)
   })
 
+  test('When the value is cleared externally, maskedValue should also be cleared', async () => {
+    const wrapper = mount(VueNumber, {
+      propsData: {
+        value: '1234.536'
+      }
+    })
+
+    await wrapper.setProps({ value: '' })
+
+    expect(wrapper.vm.maskedValue).toBe('')
+  })
+
   test('should emit input event with the new maskedValue and unmaskedValue on input', async () => {
     const wrapper = mount(VueNumber, {
       propsData: {


### PR DESCRIPTION
fix: #54 