### PR TITLE
Force numeric keyboard input on mobile

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -3,6 +3,7 @@
     v-number="config"
     type="text"
     autocomplete="off"
+    inputmode="numeric"
     :value="maskedValue"
     class="v-number vue-number-format"
     @change="change"


### PR DESCRIPTION
Input `type="text"` opens the full keyboard on touch-based devices. This addition will ask devices to open their numerical only keyboard. I found that helpful, since this input will only accept numbers in the first place.